### PR TITLE
5 merchant repo

### DIFF
--- a/lib/merchant_repository.rb
+++ b/lib/merchant_repository.rb
@@ -28,3 +28,8 @@ class MerchantRepository
   end
 
 end
+
+
+
+
+

--- a/lib/merchant_repository.rb
+++ b/lib/merchant_repository.rb
@@ -1,0 +1,30 @@
+class MerchantRepository
+  attr_reader :all
+
+  def initialize
+    @all = []
+  end
+
+  def <<(merchant)
+    all.push(merchant)
+  end
+
+  def find_by_id(id)
+    all.find do |merchant|
+      merchant.id == id
+    end
+  end
+
+  def find_by_name(name)
+    all.find do |merchant|
+      merchant.name.downcase == name.downcase
+    end
+  end
+
+  def find_all_by_name(name_stub)
+    all.find_all do |merchant|
+      merchant.name.downcase.include?(name_stub.downcase)
+    end
+  end
+
+end

--- a/test/merchant_repository_test.rb
+++ b/test/merchant_repository_test.rb
@@ -1,0 +1,96 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require './lib/merchant_repository'
+require './lib/merchant'
+
+class MerchantRepositoryTest < Minitest::Test
+
+  def test_it_exists
+    assert MerchantRepository.new
+  end
+
+  def test_it_has_no_merchants_when_initialized
+    assert_equal [], mr.all
+  end
+
+  def test_it_has_merchants
+    mr = MerchantRepository.new
+    merchant_1 = Merchant.new(1, "King Soopers")
+    merchant_2 = Merchant.new(2, "Whole Foods")
+    merchant_3 = Merchant.new(3, "Subway")
+    mr.all << merchant_1
+    mr.all << merchant_2
+    mr.all << merchant_3
+    assert_same_elements mr.all, [merchant_1, merchant_2, merchant_3]
+  end
+
+  def test_merchants_can_be_found_by_id
+    mr = MerchantRepository.new
+    merchant_1 = Merchant.new(1, "King Soopers")
+    merchant_2 = Merchant.new(2, "Whole Foods")
+    merchant_3 = Merchant.new(3, "Subway")
+    mr.all << merchant_1
+    mr.all << merchant_2
+    mr.all << merchant_3
+    assert_equal mr.find_by_id(2), merchant_2
+  end
+
+  def test_find_by_id_returns_nil_when_no_merchants_have_given_id
+    mr = MerchantRepository.new
+    merchant_1 = Merchant.new(1, "King Soopers")
+    merchant_2 = Merchant.new(2, "Whole Foods")
+    merchant_3 = Merchant.new(3, "Subway")
+    mr.all << merchant_1
+    mr.all << merchant_2
+    mr.all << merchant_3
+    assert_nil mr.find_by_id(12)
+  end
+
+  def test_find_by_name_returns_merchant_with_given_name
+    mr = MerchantRepository.new
+    merchant_1 = Merchant.new(1, "King Soopers")
+    merchant_2 = Merchant.new(2, "Whole Foods")
+    merchant_3 = Merchant.new(3, "Subway")
+    mr.all << merchant_1
+    mr.all << merchant_2
+    mr.all << merchant_3
+    assert_equal mr.find_by_name("Whole Foods"), merchant_2
+  end
+
+  def test_find_by_name_returns_nil_when_no_merchants_match_given_name
+    mr = MerchantRepository.new
+    merchant_1 = Merchant.new(1, "King Soopers")
+    merchant_2 = Merchant.new(2, "Whole Foods")
+    merchant_3 = Merchant.new(3, "Subway")
+    mr.all << merchant_1
+    mr.all << merchant_2
+    mr.all << merchant_3
+    assert_nil mr.find_by_name("Pizza Hut")
+  end
+
+  def test_find_all_by_name_returns_merchant_with_given_name_stub
+    mr = MerchantRepository.new
+    merchant_1 = Merchant.new(1, "King Soopers")
+    merchant_2 = Merchant.new(2, "Whole Foods")
+    merchant_3 = Merchant.new(3, "Subway")
+    merchant_4 = Merchant.new(4, "Dominoe's Pizza")
+    merchant_5 = Merchant.new(5, "Pizza Hut")
+    mr.all << merchant_1
+    mr.all << merchant_2
+    mr.all << merchant_3
+    mr.all << merchant_4
+    mr.all << merchant_5
+    assert_same_elements mr.find_all_by_name("Pizza"), [merchant_4, merchant_5]
+  end
+
+  def test_find_all_by_name_returns_nil_when_no_merchants_match_given_name_stub
+    mr = MerchantRepository.new
+    merchant_1 = Merchant.new(1, "King Soopers")
+    merchant_2 = Merchant.new(2, "Whole Foods")
+    merchant_3 = Merchant.new(3, "Subway")
+    mr.all << merchant_1
+    mr.all << merchant_2
+    mr.all << merchant_3
+    assert_nil mr.find_all_by_name("Pizza")
+  end
+end

--- a/test/merchant_repository_test.rb
+++ b/test/merchant_repository_test.rb
@@ -26,13 +26,13 @@ class MerchantRepositoryTest < Minitest::Test
 
   def test_merchants_can_be_added_to_the_repository
     assert_equal 3, @merchant_repository.all.count
-    @merchant_repository.all.include?(@merchant_1)
-    @merchant_repository.all.include?(@merchant_2)
-    @merchant_repository.all.include?(@merchant_3)
+    assert @merchant_repository.all.map(&:name).include?("King Soopers")
+    assert @merchant_repository.all.map(&:name).include?("Whole Foods")
+    assert @merchant_repository.all.map(&:name).include?("Subway")
   end
 
   def test_merchants_can_be_found_by_id
-    assert_equal @merchant_repository.find_by_id(2), @merchant_2
+    assert_equal 2, @merchant_repository.find_by_id(2).id
   end
 
   def test_find_by_id_returns_nil_when_no_merchants_have_given_id
@@ -40,11 +40,11 @@ class MerchantRepositoryTest < Minitest::Test
   end
 
   def test_find_by_name_returns_merchant_with_given_name
-    assert_equal @merchant_repository.find_by_name("Whole Foods"), @merchant_2
+    assert_equal "Whole Foods", @merchant_repository.find_by_name("Whole Foods").name
   end
 
   def test_find_by_name_is_case_insensitive
-    assert_equal @merchant_repository.find_by_name("whole foods"), @merchant_2
+    assert_equal "Whole Foods", @merchant_repository.find_by_name("whole foods").name
   end
 
   def test_find_by_name_returns_nil_when_no_merchants_match_given_name
@@ -52,23 +52,23 @@ class MerchantRepositoryTest < Minitest::Test
   end
 
   def test_find_all_by_name_returns_merchant_with_given_name_stub
-    merchant_4 = Merchant.new(4, "Dominoe's Pizza")
+    merchant_4 = Merchant.new(4, "Domino's Pizza")
     merchant_5 = Merchant.new(5, "Pizza Hut")
     @merchant_repository.all << merchant_4
     @merchant_repository.all << merchant_5
     results = @merchant_repository.find_all_by_name("zza")
-    assert results.include?(merchant_4)
-    assert results.include?(merchant_5)
+    assert results.map(&:name).include?("Domino's Pizza")
+    assert results.map(&:name).include?("Pizza Hut")
   end
 
   def test_find_all_by_name_is_case_insensitive
-    merchant_4 = Merchant.new(4, "Dominoe's Pizza")
+    merchant_4 = Merchant.new(4, "Domino's Pizza")
     merchant_5 = Merchant.new(5, "Pizza Hut")
     @merchant_repository.all << merchant_4
     @merchant_repository.all << merchant_5
     results = @merchant_repository.find_all_by_name("PIZZA")
-    assert results.include?(merchant_4)
-    assert results.include?(merchant_5)
+    assert results.map(&:name).include?("Domino's Pizza")
+    assert results.map(&:name).include?("Pizza Hut")
   end
 
   def test_find_all_by_name_returns_nil_when_no_merchants_match_given_name_stub
@@ -76,6 +76,6 @@ class MerchantRepositoryTest < Minitest::Test
   end
 
   def test_find_all_by_name_can_return_one_match
-    assert_equal [@merchant_2], @merchant_repository.find_all_by_name("Whole Foods")
+    assert_equal ["Whole Foods"], @merchant_repository.find_all_by_name("Whole Foods").map(&:name)
   end
 end

--- a/test/merchant_repository_test.rb
+++ b/test/merchant_repository_test.rb
@@ -6,13 +6,13 @@ require './lib/merchant'
 class MerchantRepositoryTest < Minitest::Test
 
   def setup
-    @mr = MerchantRepository.new
+    @merchant_repository = MerchantRepository.new
     @merchant_1 = Merchant.new(1, "King Soopers")
     @merchant_2 = Merchant.new(2, "Whole Foods")
     @merchant_3 = Merchant.new(3, "Subway")
-    @mr << @merchant_1
-    @mr << @merchant_2
-    @mr << @merchant_3
+    @merchant_repository << @merchant_1
+    @merchant_repository << @merchant_2
+    @merchant_repository << @merchant_3
   end
 
   def test_it_exists
@@ -20,43 +20,43 @@ class MerchantRepositoryTest < Minitest::Test
   end
 
   def test_it_has_no_merchants_when_initialized
-    mr = MerchantRepository.new
-    assert_equal [], mr.all
+    merchant_repository = MerchantRepository.new
+    assert_equal [], merchant_repository.all
   end
 
   def test_merchants_can_be_added_to_the_repository
-    assert_equal 3, @mr.all.count
-    @mr.all.include?(@merchant_1)
-    @mr.all.include?(@merchant_2)
-    @mr.all.include?(@merchant_3)
+    assert_equal 3, @merchant_repository.all.count
+    @merchant_repository.all.include?(@merchant_1)
+    @merchant_repository.all.include?(@merchant_2)
+    @merchant_repository.all.include?(@merchant_3)
   end
 
   def test_merchants_can_be_found_by_id
-    assert_equal @mr.find_by_id(2), @merchant_2
+    assert_equal @merchant_repository.find_by_id(2), @merchant_2
   end
 
   def test_find_by_id_returns_nil_when_no_merchants_have_given_id
-    assert_nil @mr.find_by_id(12)
+    assert_nil @merchant_repository.find_by_id(12)
   end
 
   def test_find_by_name_returns_merchant_with_given_name
-    assert_equal @mr.find_by_name("Whole Foods"), @merchant_2
+    assert_equal @merchant_repository.find_by_name("Whole Foods"), @merchant_2
   end
 
   def test_find_by_name_is_case_insensitive
-    assert_equal @mr.find_by_name("whole foods"), @merchant_2
+    assert_equal @merchant_repository.find_by_name("whole foods"), @merchant_2
   end
 
   def test_find_by_name_returns_nil_when_no_merchants_match_given_name
-    assert_nil @mr.find_by_name("Pizza Hut")
+    assert_nil @merchant_repository.find_by_name("Pizza Hut")
   end
 
   def test_find_all_by_name_returns_merchant_with_given_name_stub
     merchant_4 = Merchant.new(4, "Dominoe's Pizza")
     merchant_5 = Merchant.new(5, "Pizza Hut")
-    @mr.all << merchant_4
-    @mr.all << merchant_5
-    results = @mr.find_all_by_name("zza")
+    @merchant_repository.all << merchant_4
+    @merchant_repository.all << merchant_5
+    results = @merchant_repository.find_all_by_name("zza")
     assert results.include?(merchant_4)
     assert results.include?(merchant_5)
   end
@@ -64,18 +64,18 @@ class MerchantRepositoryTest < Minitest::Test
   def test_find_all_by_name_is_case_insensitive
     merchant_4 = Merchant.new(4, "Dominoe's Pizza")
     merchant_5 = Merchant.new(5, "Pizza Hut")
-    @mr.all << merchant_4
-    @mr.all << merchant_5
-    results = @mr.find_all_by_name("PIZZA")
+    @merchant_repository.all << merchant_4
+    @merchant_repository.all << merchant_5
+    results = @merchant_repository.find_all_by_name("PIZZA")
     assert results.include?(merchant_4)
     assert results.include?(merchant_5)
   end
 
   def test_find_all_by_name_returns_nil_when_no_merchants_match_given_name_stub
-    assert_equal [], @mr.find_all_by_name("Pizza")
+    assert_equal [], @merchant_repository.find_all_by_name("Pizza")
   end
 
   def test_find_all_by_name_can_return_one_match
-    assert_equal [@merchant_2], @mr.find_all_by_name("Whole Foods")
+    assert_equal [@merchant_2], @merchant_repository.find_all_by_name("Whole Foods")
   end
 end

--- a/test/merchant_repository_test.rb
+++ b/test/merchant_repository_test.rb
@@ -5,92 +5,77 @@ require './lib/merchant'
 
 class MerchantRepositoryTest < Minitest::Test
 
+  def setup
+    @mr = MerchantRepository.new
+    @merchant_1 = Merchant.new(1, "King Soopers")
+    @merchant_2 = Merchant.new(2, "Whole Foods")
+    @merchant_3 = Merchant.new(3, "Subway")
+    @mr << @merchant_1
+    @mr << @merchant_2
+    @mr << @merchant_3
+  end
+
   def test_it_exists
     assert MerchantRepository.new
   end
 
   def test_it_has_no_merchants_when_initialized
+    mr = MerchantRepository.new
     assert_equal [], mr.all
   end
 
-  def test_it_has_merchants
-    mr = MerchantRepository.new
-    merchant_1 = Merchant.new(1, "King Soopers")
-    merchant_2 = Merchant.new(2, "Whole Foods")
-    merchant_3 = Merchant.new(3, "Subway")
-    mr.all << merchant_1
-    mr.all << merchant_2
-    mr.all << merchant_3
-    assert_same_elements mr.all, [merchant_1, merchant_2, merchant_3]
+  def test_merchants_can_be_added_to_the_repository
+    assert_equal 3, @mr.all.count
+    @mr.all.include?(@merchant_1)
+    @mr.all.include?(@merchant_2)
+    @mr.all.include?(@merchant_3)
   end
 
   def test_merchants_can_be_found_by_id
-    mr = MerchantRepository.new
-    merchant_1 = Merchant.new(1, "King Soopers")
-    merchant_2 = Merchant.new(2, "Whole Foods")
-    merchant_3 = Merchant.new(3, "Subway")
-    mr.all << merchant_1
-    mr.all << merchant_2
-    mr.all << merchant_3
-    assert_equal mr.find_by_id(2), merchant_2
+    assert_equal @mr.find_by_id(2), @merchant_2
   end
 
   def test_find_by_id_returns_nil_when_no_merchants_have_given_id
-    mr = MerchantRepository.new
-    merchant_1 = Merchant.new(1, "King Soopers")
-    merchant_2 = Merchant.new(2, "Whole Foods")
-    merchant_3 = Merchant.new(3, "Subway")
-    mr.all << merchant_1
-    mr.all << merchant_2
-    mr.all << merchant_3
-    assert_nil mr.find_by_id(12)
+    assert_nil @mr.find_by_id(12)
   end
 
   def test_find_by_name_returns_merchant_with_given_name
-    mr = MerchantRepository.new
-    merchant_1 = Merchant.new(1, "King Soopers")
-    merchant_2 = Merchant.new(2, "Whole Foods")
-    merchant_3 = Merchant.new(3, "Subway")
-    mr.all << merchant_1
-    mr.all << merchant_2
-    mr.all << merchant_3
-    assert_equal mr.find_by_name("Whole Foods"), merchant_2
+    assert_equal @mr.find_by_name("Whole Foods"), @merchant_2
+  end
+
+  def test_find_by_name_is_case_insensitive
+    assert_equal @mr.find_by_name("whole foods"), @merchant_2
   end
 
   def test_find_by_name_returns_nil_when_no_merchants_match_given_name
-    mr = MerchantRepository.new
-    merchant_1 = Merchant.new(1, "King Soopers")
-    merchant_2 = Merchant.new(2, "Whole Foods")
-    merchant_3 = Merchant.new(3, "Subway")
-    mr.all << merchant_1
-    mr.all << merchant_2
-    mr.all << merchant_3
-    assert_nil mr.find_by_name("Pizza Hut")
+    assert_nil @mr.find_by_name("Pizza Hut")
   end
 
   def test_find_all_by_name_returns_merchant_with_given_name_stub
-    mr = MerchantRepository.new
-    merchant_1 = Merchant.new(1, "King Soopers")
-    merchant_2 = Merchant.new(2, "Whole Foods")
-    merchant_3 = Merchant.new(3, "Subway")
     merchant_4 = Merchant.new(4, "Dominoe's Pizza")
     merchant_5 = Merchant.new(5, "Pizza Hut")
-    mr.all << merchant_1
-    mr.all << merchant_2
-    mr.all << merchant_3
-    mr.all << merchant_4
-    mr.all << merchant_5
-    assert_same_elements mr.find_all_by_name("Pizza"), [merchant_4, merchant_5]
+    @mr.all << merchant_4
+    @mr.all << merchant_5
+    results = @mr.find_all_by_name("zza")
+    assert results.include?(merchant_4)
+    assert results.include?(merchant_5)
+  end
+
+  def test_find_all_by_name_is_case_insensitive
+    merchant_4 = Merchant.new(4, "Dominoe's Pizza")
+    merchant_5 = Merchant.new(5, "Pizza Hut")
+    @mr.all << merchant_4
+    @mr.all << merchant_5
+    results = @mr.find_all_by_name("PIZZA")
+    assert results.include?(merchant_4)
+    assert results.include?(merchant_5)
   end
 
   def test_find_all_by_name_returns_nil_when_no_merchants_match_given_name_stub
-    mr = MerchantRepository.new
-    merchant_1 = Merchant.new(1, "King Soopers")
-    merchant_2 = Merchant.new(2, "Whole Foods")
-    merchant_3 = Merchant.new(3, "Subway")
-    mr.all << merchant_1
-    mr.all << merchant_2
-    mr.all << merchant_3
-    assert_nil mr.find_all_by_name("Pizza")
+    assert_equal [], @mr.find_all_by_name("Pizza")
+  end
+
+  def test_find_all_by_name_can_return_one_match
+    assert_equal [@merchant_2], @mr.find_all_by_name("Whole Foods")
   end
 end


### PR DESCRIPTION
closes #5 

Hi @alfosco - at the moment, this all passes.  But once you (correctly) make the change so that we're taking in arguments to the `Merchant` class as a hash (e.g.
`m = Merchant.new({:id => 5, :name => "Whole Foods"})`
then the tests will need to be updated to comply with that format.  I'm happy to make those changes when it's time.