### PR TITLE
added transaction attributes

### DIFF
--- a/lib/transaction.rb
+++ b/lib/transaction.rb
@@ -1,0 +1,17 @@
+class Transaction
+
+  attr_reader :id,
+              :invoice_id,
+              :credit_card_number,
+              :credit_card_expiration_date,
+              :result
+
+  def initialize(data)
+    @id = data[:id]
+    @invoice_id = data[:invoice_id]
+    @credit_card_number = data[:credit_card_number]
+    @credit_card_expiration_date = data[:credit_card_expiration_date]
+    @result = data[:result]
+  end
+
+end

--- a/test/transaction_test.rb
+++ b/test/transaction_test.rb
@@ -1,0 +1,42 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require './lib/transaction'
+
+class TransactionTest < Minitest::Test
+
+  def setup
+    @transaction_id = 6
+    @transaction_invoice_id = 8
+    @transaction_credit_card_number = "4242424242424242"
+    @transaction_credit_card_expiration_date = "0220"
+    @transaction_result = "success"
+    @transaction = Transaction.new({
+      :id => @transaction_id,
+      :invoice_id => @transaction_invoice_id,
+      :credit_card_number => @transaction_credit_card_number,
+      :credit_card_expiration_date => @transaction_credit_card_expiration_date,
+      :result => @transaction_result
+    })
+  end
+
+  def test_transaction_has_an_id
+    assert_equal @transaction_id, @transaction.id
+  end
+
+  def test_transaction_has_an_invoice_id
+    assert_equal @transaction_invoice_id, @transaction.invoice_id
+  end
+
+  def test_transaction_has_a_credit_card_number
+    assert_equal @transaction_credit_card_number, @transaction.credit_card_number
+  end
+
+  def test_transaction_has_a_credit_card_expiration_date
+    assert_equal @transaction_credit_card_expiration_date, @transaction.credit_card_expiration_date
+  end
+
+  def test_transaction_has_a_result
+    assert_equal @transaction_result, @transaction.result
+  end
+
+end


### PR DESCRIPTION
closes #10 
Will need to be modified to reflect 'created_at' and 'updated_at' methods and for the 'result' method to return when a credit card fails.